### PR TITLE
Provide missing link for game animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Robot code for 2019 FRC competition for team 1741
 
 ## Links
-* [Game Animation]() Soon
+* [Game Animation](https://www.youtube.com/watch?v=Mew6G_og-PI)
 * [Game Manual](https://www.firstinspires.org/resource-library/frc/competition-manual-qa-system)
 
 ---


### PR DESCRIPTION
## Problem

The game animation link in the README is _dead_.

## Solution

I put some Youtube link in there.

## Testing Notes

Click the link to see if it's correct, or some random garbage Fortnite ElsaGate video or something.