### PR TITLE
Build tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,10 @@ bin/
 
 # Ignore Swap Files
 *.swp
+
+# Ignore local gradle.properties file. To use gradle locally if you have Windows, try
+# putting this in a gradle.properties file in the root of this repository: 
+# 
+# org.gradle.java.home=C:\\Users\\Public\\frc2019\\jdk
+#
+gradle.properties

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,8 @@
     ".classpath": true,
     ".project": true
   },
-  "wpilib.online": true
+  "wpilib.online": true,
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.detectIndentation": true
 }


### PR DESCRIPTION
## Problem

The local build setup is messy.

## Solution

Allow us to set some sane defaults in `gradle.properties` and ensure we're all using the same indentation settings.

