### PR TITLE
Use openjdk11 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk11
+  - openjdk11
 
 install:
   - ./gradlew assemble


### PR DESCRIPTION
## Problem

`oraclejdk11` is bad.

## Solution

`openjdk11` is ~bad~ good.

## Testing Notes

Does `travis` work?  🤔 
