### PR TITLE
Fix simulation voltage logging

### DIFF
--- a/simulator_config/simulator_config.yml
+++ b/simulator_config/simulator_config.yml
@@ -25,11 +25,9 @@ mPwm:
     mInverted: true
     mMotorType: CIM
     mNumMotors: 1
-  mMotorSimConfig: !!com.snobot.simulator.motor_sim.RotationalLoadMotorSimulationConfig
-    mArmCenterOfMass: 0.0
-    mArmMass: 0.0
-    mConstantAssistTorque: 0.0
-    mOverCenterAssistTorque: 0.0
+  mMotorSimConfig: !!com.snobot.simulator.motor_sim.StaticLoadMotorSimulationConfig
+    mConversionFactor: 0.16666666666
+    mLoad: 0.6
   mName: Left Front Drive
   mType: com.snobot.simulator.simulator_components.ctre.CtreTalonSrxSpeedControllerSim
 - mHandle: 105
@@ -40,11 +38,9 @@ mPwm:
     mInverted: true
     mMotorType: CIM
     mNumMotors: 1
-  mMotorSimConfig: !!com.snobot.simulator.motor_sim.RotationalLoadMotorSimulationConfig
-    mArmCenterOfMass: 0.0
-    mArmMass: 0.0
-    mConstantAssistTorque: 0.0
-    mOverCenterAssistTorque: 0.0
+  mMotorSimConfig: !!com.snobot.simulator.motor_sim.StaticLoadMotorSimulationConfig
+    mConversionFactor: 0.16666666666
+    mLoad: 0.6
   mName: Left Back Drive
   mType: com.snobot.simulator.simulator_components.ctre.CtreTalonSrxSpeedControllerSim
 - mHandle: 106
@@ -55,11 +51,9 @@ mPwm:
     mInverted: false
     mMotorType: CIM
     mNumMotors: 1
-  mMotorSimConfig: !!com.snobot.simulator.motor_sim.RotationalLoadMotorSimulationConfig
-    mArmCenterOfMass: 0.0
-    mArmMass: 0.0
-    mConstantAssistTorque: 0.0
-    mOverCenterAssistTorque: 0.0
+  mMotorSimConfig: !!com.snobot.simulator.motor_sim.StaticLoadMotorSimulationConfig
+    mConversionFactor: 0.16666666666
+    mLoad: 0.6
   mName: Right Front Drive
   mType: com.snobot.simulator.simulator_components.ctre.CtreTalonSrxSpeedControllerSim
 - mHandle: 107
@@ -70,11 +64,9 @@ mPwm:
     mInverted: false
     mMotorType: CIM
     mNumMotors: 1
-  mMotorSimConfig: !!com.snobot.simulator.motor_sim.RotationalLoadMotorSimulationConfig
-    mArmCenterOfMass: 0.0
-    mArmMass: 0.0
-    mConstantAssistTorque: 0.0
-    mOverCenterAssistTorque: 0.0
+  mMotorSimConfig: !!com.snobot.simulator.motor_sim.StaticLoadMotorSimulationConfig
+    mConversionFactor: 0.16666666666
+    mLoad: 0.6
   mName: Right Back Drive
   mType: com.snobot.simulator.simulator_components.ctre.CtreTalonSrxSpeedControllerSim
 mRelays: []

--- a/simulator_config/simulator_config.yml
+++ b/simulator_config/simulator_config.yml
@@ -4,6 +4,9 @@ mAnalogIn:
 - mHandle: 0
   mName: Analog In 0
   mType: com.snobot.simulator.module_wrapper.wpi.WpiAnalogInWrapper
+- mHandle: 1
+  mName: Analog In 1
+  mType: com.snobot.simulator.module_wrapper.wpi.WpiAnalogInWrapper
 mAnalogOut: []
 mDefaultI2CWrappers: {}
 mDefaultSpiWrappers: {}
@@ -13,6 +16,67 @@ mDigitalIO:
   mType: com.snobot.simulator.module_wrapper.wpi.WpiDigitalIoWrapper
 mEncoders: []
 mGyros: []
-mPwm: []
+mPwm:
+- mHandle: 104
+  mMotorModelConfig:
+    mGearReduction: 10.7142857143
+    mGearboxEfficiency: 0.9
+    mHasBrake: false
+    mInverted: true
+    mMotorType: CIM
+    mNumMotors: 1
+  mMotorSimConfig: !!com.snobot.simulator.motor_sim.RotationalLoadMotorSimulationConfig
+    mArmCenterOfMass: 0.0
+    mArmMass: 0.0
+    mConstantAssistTorque: 0.0
+    mOverCenterAssistTorque: 0.0
+  mName: Left Front Drive
+  mType: com.snobot.simulator.simulator_components.ctre.CtreTalonSrxSpeedControllerSim
+- mHandle: 105
+  mMotorModelConfig:
+    mGearReduction: 10.7142857143
+    mGearboxEfficiency: 0.9
+    mHasBrake: false
+    mInverted: true
+    mMotorType: CIM
+    mNumMotors: 1
+  mMotorSimConfig: !!com.snobot.simulator.motor_sim.RotationalLoadMotorSimulationConfig
+    mArmCenterOfMass: 0.0
+    mArmMass: 0.0
+    mConstantAssistTorque: 0.0
+    mOverCenterAssistTorque: 0.0
+  mName: Left Back Drive
+  mType: com.snobot.simulator.simulator_components.ctre.CtreTalonSrxSpeedControllerSim
+- mHandle: 106
+  mMotorModelConfig:
+    mGearReduction: 10.7142857143
+    mGearboxEfficiency: 0.9
+    mHasBrake: false
+    mInverted: false
+    mMotorType: CIM
+    mNumMotors: 1
+  mMotorSimConfig: !!com.snobot.simulator.motor_sim.RotationalLoadMotorSimulationConfig
+    mArmCenterOfMass: 0.0
+    mArmMass: 0.0
+    mConstantAssistTorque: 0.0
+    mOverCenterAssistTorque: 0.0
+  mName: Right Front Drive
+  mType: com.snobot.simulator.simulator_components.ctre.CtreTalonSrxSpeedControllerSim
+- mHandle: 107
+  mMotorModelConfig:
+    mGearReduction: 10.7142857143
+    mGearboxEfficiency: 0.9
+    mHasBrake: false
+    mInverted: false
+    mMotorType: CIM
+    mNumMotors: 1
+  mMotorSimConfig: !!com.snobot.simulator.motor_sim.RotationalLoadMotorSimulationConfig
+    mArmCenterOfMass: 0.0
+    mArmMass: 0.0
+    mConstantAssistTorque: 0.0
+    mOverCenterAssistTorque: 0.0
+  mName: Right Back Drive
+  mType: com.snobot.simulator.simulator_components.ctre.CtreTalonSrxSpeedControllerSim
 mRelays: []
 mSimulatorComponents: []
+mSolenoids: []

--- a/src/main/java/frc/robot/Drivetrain.java
+++ b/src/main/java/frc/robot/Drivetrain.java
@@ -95,8 +95,8 @@ public class Drivetrain implements Loggable {
   public void log(DataLogger logger) {
     for (var entry : motorsByName()) {
       var talon = entry.getValue();
-      logger.log(entry.getKey()+"Current", talon.getOutputCurrent());
-      logger.log(entry.getKey()+"Voltage", talon.getBusVoltage());
+      logger.log(entry.getKey()+"Current", getOutputCurrent(talon));
+      logger.log(entry.getKey()+"Voltage", getBusVoltage(talon));
       logger.log(entry.getKey()+"Value", talon.get());
       logger.log(entry.getKey()+"Position", talon.getSelectedSensorPosition());
       logger.log(entry.getKey()+"Velocity", talon.getSelectedSensorVelocity());
@@ -116,5 +116,21 @@ public class Drivetrain implements Loggable {
     list.add(Map.entry("RightRear", this.rightSlave));
 
     return list;
+  }
+
+  public Double getOutputCurrent(WPI_TalonSRX talon) {
+    if (RuntimeDetector.isSimulation()) {
+      return 0.0;
+    } else {
+      return talon.getOutputCurrent();
+    }
+  }
+
+  public Double getBusVoltage(WPI_TalonSRX talon) {
+    if (RuntimeDetector.isSimulation()) {
+      return 0.0;
+    } else {
+      return talon.getBusVoltage();
+    }
   }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -230,7 +230,6 @@ public class Robot extends TimedRobot {
   @Override
   public void teleopPeriodic() {
     // Run teleop code (interpreting input, etc.)
-    System.out.println(String.format("Pressure: %2.2f", pressureSensor.getPressure()));
     drive.arcadeDrive(xbc.getX(GenericHID.Hand.kLeft),
                       xbc.getY(GenericHID.Hand.kLeft));
     log();


### PR DESCRIPTION
## Problem

The simulator errors out on `GetOutputCurrent` and `GetBusVoltage` calls for `WPI_TalonSRX`.

## Solution

Break out the logging calls into separate methods that check if the code is running in a simulation or on the actual robot.

## Testing Notes

Run the simulation and confirm the following errors are not occuring:
```
2019-02-12 15:09:29 ERROR com.snobot.simulator.simulator_components.ctre.CtreManager:304 - Unknown motor callback: GetOutputCurrent
2019-02-12 15:09:29 ERROR com.snobot.simulator.simulator_components.ctre.CtreManager:304 - Unknown motor callback: GetBusVoltage
```
